### PR TITLE
Propose discussion of opcache

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -1,13 +1,18 @@
-# Next Meeting Agenda
+# Next Technical Steering Committee Meeting Agenda
 
-Agenda for the April 2020 TSC meeting. Please file pull requests to add, or
-discuss items to add, to the agenda.
+- Date: 2020-04-06
+- Time: 19:00 UTC
+
+Please file pull requests to add, or discuss items to add, to the agenda.
 
 
 ## Items to discuss
 
-* CLI tooling for Laminas MVC, Mezzio, components
-* Full example / demo applications
-  * developed under https://github.com/laminas-tutorials
-  * follows best practices and implements typical features
-  * basis for new tutorials
+- CLI tooling for Laminas MVC, Mezzio, components
+- Full example / demo applications
+  - developed under https://github.com/laminas-tutorials
+  - follows best practices and implements typical features
+  - basis for new tutorials
+- Opcache Preloading for MVC, Mezzio
+  - @weierophinney has done some research, and posted an RFC for discussion:
+    https://discourse.laminas.dev/t/rfc-opache-preloading-for-mezzio-and-mvc/1442


### PR DESCRIPTION
This patch actually does two things:

- Sets the date and time for the meeting, per consensus amongst the TSC members.
- Adds an item to discuss my opcache RFC.