### PR TITLE
Adds Security group agenda item for April meeting

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -16,3 +16,7 @@ Please file pull requests to add, or discuss items to add, to the agenda.
 - Opcache Preloading for MVC, Mezzio
   - @weierophinney has done some research, and posted an RFC for discussion:
     https://discourse.laminas.dev/t/rfc-opache-preloading-for-mezzio-and-mvc/1442
+- Security Group
+  - @weierophinney has setup the security@getlaminas.org email, but we need a
+    new security group, as the bulk of those previously on it are either inactive
+    or left the TSC. Who should get these emails?


### PR DESCRIPTION
Since the bulk of our security group members are either inactive or have left the project, we need to create a new one.