### PR TITLE
Discuss listing companies that use Laminas on website

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -7,3 +7,16 @@ Please file pull requests to add, or discuss items to add, to the agenda.
 
 ## Items to discuss
 
+- Should we have a list of "companies using Laminas" for the website?
+  On the ZF website, we had a section of the homepage that shared logos of
+  companies using the framework. This helped establish the breadth of adoption,
+  which helped promote the ecosystem.
+
+  Should we do this for Laminas? Matthew has asked the LF legal representative,
+  and he has indicated:
+
+  > [The] requirement [...] is that you have permission for us to list their
+  > logo. Generally an email request that we display a logo and storing that email
+  > will be enough
+
+  Are we interested in doing this?


### PR DESCRIPTION
In the ZF days, we used to list companies using ZF on the homepage. I'm curious if we'd want to do this again as Laminas.