### PR TITLE
[agenda] Should we use GreetBot?

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -7,3 +7,19 @@ Please file pull requests to add, or discuss items to add, to the agenda.
 
 ## Items to discuss
 
+- GreetBot
+  Last month, when discussing how to reduce noise in Slack, we discussed ways we
+  can direct Slack users towards appropriate engagement — e.g., pushing them to
+  use the forums to ask questions, reminding them of the TSC meetings, etc.
+  Aleksei (@Xerkus) pointed me towards [GreetBot](https://greet.bot) as a
+  possible solution.
+
+  Their free plan only provides one message on signup, and a message for joining
+  a channel (exactly ONE channel). Their "Plus" plan is $12/month, and offers up
+  to 15 messages per user (e.g., a signup message, a reminder a week in, etc.),
+  as well as messages per-channel (e.g., to tell them what the purpose of a
+  channel is, where to go on the forums for more help, where the docs are,
+  etc.). I reached out to see if they have OSS discounts, and they do: half-off.
+
+  I'm willing to pay for this out of my GitHub sponsors funds; do we want to do
+  this?


### PR DESCRIPTION
During last month's TSC meeting, and in TSC discussions afterwards, we discussed using [GreetBot](https://greet.bot) as a possible way to help get information in front of Slack users, so that they know where documentation is, where to report issues, and where to ask questions (the forums!).

I've looked into pricing, and have questions.