### PR TITLE
Voting protocol: updates per 2020-08-03 meeting

### DIFF
--- a/processes/VOTING.md
+++ b/processes/VOTING.md
@@ -1,26 +1,40 @@
 # Technical Steering Committee Voting Process
 
 While the Project aims to operate as a consensus-based community, many decisions
-will require a vote in order to move forward:approval of new repositories
+will require a vote in order to move forward: approval of new repositories
 or subprojects, approval of archival/abandonment of repositories or subprojects,
 approval of new maintainers, selection of Project Lead, etc.
 
-Voting will happen either within a meeting, or via online vote.
+Voting will happen either within a meeting, or via electronic vote.
 
-Meetings will happen on the **{to be determined day of the month}**. An agenda
-will be provided as an issue on the issue tracker of this repository, with the
-ability for anybody to request an item be added, modified, or removed.
+For purposes of this document, when 50% results in a fraction, `ceil(50%)` is
+implied.
 
-Quorum for a meeting requires at least 2/3 of all voting TSC members present. If
-quorum is not met, the meeting may continue, but no votes or decisions may be
-made.
+## TSC Meeting Votes
 
-A vote may be called during a meeting. Such votes pass only if a 2/3 majority of
-all TSC members, not just those in attendance, approve.
+Meetings will happen on the first Monday of each month. An agenda will be
+provided in the repository, with the ability for anybody to request an item be
+added, modified, or removed via pull request.
 
-A vote may also be initiated via **{a to be determined method}**. In such cases,
-as with meeting votes, a 2/3 majority of all voting members is required for
-approval.
+Per the charter, quorum for a meeting requires at least 50% of all TSC members
+present. If quorum is not met, the meeting may continue, but no votes or
+decisions may be made.
+
+A vote may be called during a meeting. Such votes pass only if a simple majority
+of those present in the meeting approve. If a vote passes, but does not
+receive 50% of all TSC members (not just those present) approving, we will hold
+an asynchronous electronic vote to validate the decision.
+
+## Asynchronous Electronic Votes
+
+A vote may be initiated outside meetings, using technologies such as Google
+Forms or [ADoodle](https://adoodle.org); anonymous votes are encouraged, but
+all voting results must be published publicly on completion (per the charter).
+In such cases, per the charter, a decision is only binding if at least 50% of
+all TSC members approve.
+
+The voting period for asynchronous votes is 2 weeks, or until all TSC members
+have voted, whichever comes first.
 
 ## Decisions requiring a vote
 


### PR DESCRIPTION
This document has been present for some time, but was not updated to reflect the charter once the charter was approved and accepted by the LF.

The LF allows us to define our own processes, including how voting is held, so long as those processes do not conflict with the charter. The previous text conflicted with the charter. The proposed changes are in line with the charter, and contain the [clarifications we voted on during the TSC meeting held 2020-08-03](https://github.com/laminas/technical-steering-committee/pull/39/files#diff-8b5332138fd8c5a5d1edf411fc2a0469R169-R176).