### PR TITLE
Add an issue template for requesting to become a maintainer

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_maintainership.md
+++ b/.github/ISSUE_TEMPLATE/request_maintainership.md
@@ -1,0 +1,25 @@
+---
+name: Request Maintainership
+about: Use this template to apply to maintain a Laminas, Laminas API Tools, or Mezzio repository.
+title: "[MAINTAINER REQUEST]: [REPOSITORY]"
+labels: Maintainer Requseet
+---
+
+| Q               | A |
+| --------------- | - |
+| Repository      |   |
+| Github username |   |
+
+This is a request to become a **maintainer** on the repository **{repository name here; use organization/repository format}**.
+
+- [ ] I have read and understood the [maintainers guide](https://github.com/laminas/technical-steering-committee/blob/main/MAINTAINERS.md), and understand:
+  - [ ] What constitutes a backwards compatibility break.
+  - [ ] What constitutes a bugfix.
+  - [ ] What constitutes a feature request and/or warrants a feature release.
+  - [ ] How to create a release.
+  - [ ] How to run unit tests.
+  - [ ] How to run coding standards checks and how to fix coding standards issues.
+  - [ ] How to update and provide new documentation.
+- [ ] I have time for the forseeable future to triage issues, merge pull requests, and create releases.
+
+<!-- Briefly tell us why you want to maintain this repository -->


### PR DESCRIPTION
Per discussion in previous TSC meetings, and during today's meeting, this patch adds an issue template for requesting to become a maintainer of a repository.

We can then link to it using https://github.com/laminas/technical-steering-committee/issues/new?template=request_maintainership.md

The template prompts for:

- repository to maintain
- github username
- a checklist to certify they have read the maintainer's guide, and understand it
- a freeform prompt to determine why they want to maintain it

Depends on #45 being completed first.