### PR TITLE
Fix a broken link in minutes from 2021-05-03

### DIFF
--- a/meetings/minutes/2021-05-03-TSC-Minutes.md
+++ b/meetings/minutes/2021-05-03-TSC-Minutes.md
@@ -152,8 +152,9 @@ We just need a volunteer to make it happen.
 
 ### laminas-db Maintainer Vote
 
-Per [#73](/laminas/technical-steering-committee/issues/73), we have three laminas-db maintainer nominations to vote on, and [Matthew](https://github.com/weierophinney) suggests doing it during the meeting to expedite the vote.
-As a reminder, the individuals nominated are:
+Per [#73](https://github.com/laminas/technical-steering-committee/issues/73), we have three laminas-db maintainer
+nominations to vote on, and [Matthew](https://github.com/weierophinney) suggests doing it during the meeting to expedite
+the vote. As a reminder, the individuals nominated are:
 
 - [Massi Cavicchioli (@MassiCav)](https://github.com/MassiCav)
 - [Clark Everetts (@clarkphp)](https://github.com/clarkphp)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

In the Laminas Slack someone asked about the status of laminas-db and when I searched about it in the minutes I noticed a broken link there. This PR fixes the broken link to the corresponding issue.