### PR TITLE
Add agenda item for mezzio-swoole fork for openswoole

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -12,3 +12,15 @@ Matthew Setter would like to move his project, [settermjd/laminas-static-pages](
 > It simplifies rendering static pages in Mezzio applications, avoiding the need to create handlers and handler factories to render static content templates. 
 
 While he is happy to keep maintaining the package personally, he thought that it would be a good addition to the Laminas project. 
+
+### Fork mezzio/mezzio-swoole as mezzio/mezzio-openswoole
+
+Openswoole starting with version 22.0 began diverging from swoole with new unique functionality, existing api deprecated and some previously deprecated api removed. See https://openswoole.com/article/v22-0-0-released#changelog
+For example, method `swoole_set_process_name()` was replaced with `OpenSwoole\Util::setProcessName()`, see https://github.com/mezzio/mezzio-swoole/issues/110
+
+It is evident that supporting both extensions within same component will be increasingly difficult and potentially stiffing for addition of a new functionality.
+
+I propose we:
+- Fork mezzio/mezzio-swoole as mezzio/mezzio-openswoole.
+- Declare explicit dependency on respective extensions with version ranges
+- Improve CI for those two components to run unit and integration tests in matrix with every supported extension version. At minimum with each major and ideally with each minor as well.


### PR DESCRIPTION
Openswoole is diverging from swoole with newer releases.
mezzio-swoole should be forked to provide better support for each extension.