### PR TITLE
Update agenda.md to include `Roave/BackwardCompatibilityCheck` in laminas builds

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -8,3 +8,4 @@ Please file pull requests to add, or discuss items to add, to the agenda.
 ## Items to Discuss
 
 - Whether to add Slamdunk and settermjd as laminas-mime and laminas-mail mainteiners or to mark laminas-mail as a security only package.
+- Whether add https://github.com/Roave/BackwardCompatibilityCheck as a default job to be run in the `laminas-ci-matrix > laminas-continuous-integration` CI


### PR DESCRIPTION
I always assumed it was already part of the build, and I almost released an unwanted BC Break for that:

https://github.com/laminas/laminas-form/pull/248#pullrequestreview-1747650048