### PR TITLE
Agenda item: Place for technical discussion

### DIFF
--- a/meetings/agenda.md
+++ b/meetings/agenda.md
@@ -12,3 +12,23 @@ Please file pull requests to add, or discuss items to add, to the agenda.
 [@gsteel](https://github.com/gsteel/) would like to nominate  Richard McHale ([@ramchale](https://github.com/ramchale)) as a maintainer of `laminas-filter`, `laminas-inputfilter` and `laminas-validator`.
 
 Richard has provided a number of high quality contributions to laminas-filter that were instrumental in getting v3 over the finish line, and has expressed his interest in continuing to help triage issues, review PRs and perform maintenance duties as a member of the team.
+
+### Place for Discussion
+
+At the moment we are using different channels for different discussions. 
+The Discourse forum is used for user questions, and I would not like to change that at this point.
+But for technical discussions, I would like to have a single place where we can discuss all topics.
+
+We have issues and PRs on GitHub, but they are not the best place for discussions, especially when it comes to future developments.
+And we have Slack, but it is more a chat tool, and not the best place for technical discussions either, because it is not persistent and not topic-related.
+Then we have the discussion feature open on GitHub, but only for some repositories.
+For example:
+
+- https://github.com/laminas/laminas-cli/discussions
+- https://github.com/laminas/laminas-view/discussions
+- https://github.com/laminas/technical-steering-committee/discussions
+
+But I would not open the discussions on all repositories.
+So the question is: do we want to have a single place for discussions, and if yes, which one?
+On a specific repository or on for the whole organization?
+Or there are other options/ideas?


### PR DESCRIPTION
Proposed creating a single platform for technical discussions to improve organization and accessibility. Outlined current challenges with using multiple channels like GitHub issues, Slack, and Discourse, and posed questions on the preferred approach for centralizing discussions.